### PR TITLE
Fix instructions to work locally

### DIFF
--- a/text-bison-notebook.ipynb
+++ b/text-bison-notebook.ipynb
@@ -217,7 +217,7 @@
       "source": [
         "### (Optional) Update Configuration\n",
         "\n",
-        "If needed, you can update the default configuration for [tuner](/pkg/tuner/metadata.py) and [predictor](/pkg/tuner/metadata.py) packages."
+        "If needed, you can update the default configuration for [tuner](pkg/tuner/metadata.py) and [predictor](pkg/tuner/metadata.py) packages."
       ]
     },
     {
@@ -343,9 +343,9 @@
         "\n",
         "RLHF tuning uses three datasets:\n",
         "\n",
-        "* Prompt [dataset](/data/prompt/shard-00000-of-00002.jsonl) with unlabelled prompts.\n",
-        "* Human preference [dataset](/data/preference/shard-00000-of-00002.jsonl) with prompts labelled with preferences from humans.\n",
-        "* Evaluation [dataset](/data/evaluation/shard-00000-of-00002.jsonl) with unlabeled prompts for prediction after the model is tuned. This is optional.\n",
+        "* Prompt [dataset](data/prompt/shard-00000-of-00002.jsonl) with unlabelled prompts.\n",
+        "* Human preference [dataset](data/preference/shard-00000-of-00002.jsonl) with prompts labelled with preferences from humans.\n",
+        "* Evaluation [dataset](data/evaluation/shard-00000-of-00002.jsonl) with unlabeled prompts for prediction after the model is tuned. This is optional.\n",
         "  \n",
         "Learn more about data for RLFH in Vertex AI [documentation]. \n",
         "\n",
@@ -419,7 +419,7 @@
       "source": [
         "## Calculate Training Steps\n",
         "\n",
-        "Choose a suitable value for the number of reward model and reinforcing learning train steps to avoid overfitting. This depends on the size of the datasets. If needed, configure the values in [metadata.py](/pkg/trainer/metadata.py)."
+        "Choose a suitable value for the number of reward model and reinforcing learning train steps to avoid overfitting. This depends on the size of the datasets. If needed, configure the values in [metadata.py](pkg/tuner/metadata.py)."
       ]
     },
     {

--- a/text-bison-notebook.ipynb
+++ b/text-bison-notebook.ipynb
@@ -265,18 +265,11 @@
         "\n",
         "**2. Local**\n",
         "\n",
-        "If you are running the notebook locally, uncomment and run:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ce6043da7b33"
-      },
-      "outputs": [],
-      "source": [
-        "# ! gcloud auth login"
+        "If you are running the notebook locally, run this lcoally (it will not work within the context of the notebook):\n",
+        "\n",
+        "```\n",
+        "gcloud auth application-default login\n",
+        "```"
       ]
     },
     {


### PR DESCRIPTION
Where "locally" for me means running the notebook via Cloud
Workstations.

There were two main issues:
* Commands run from the notebook can't take user input
  (https://stackoverflow.com/questions/44604027/running-interactive-command-line-code-from-jupyter-notebook).
* `gcloud auth login` doesn't set up the environment correctly for
  the libs that are being used here; after running that command the
  default service account from my cloud workstation was being used
  (https://cloud.google.com/iam/docs/service-agents#workstations-vm-default-service-account)
  but after `gcloud auth application-default login` this switched to
  my own credentials

Alternatively, if you want to run the command from the notebook you can
use this beautiful block of code:

```python
import pexpect
p = pexpect.spawn('gcloud auth application-default login')
while True:
    try:
        p.expect('code:  ')
        print(p.before)
        p.sendline(raw_input('>>> '))
    except pexpect.EOF:
        break

```

Also fixed paths in the notebook so they would link properly to other files in the repo.