### PR TITLE
Need storage.admin to avoid errors when submitting pipeline

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -82,26 +82,16 @@ Make sure the default Compute Engine [service account][sa] has sufficient permis
      --role="roles/aiplatform.user"
      ```
 
- 5. Add the `roles/storage.objectCreator` role.
+ 5. Add the `roles/storage.admin` role.
 
      ```shell
      gcloud projects add-iam-policy-binding $PROJECT_ID \
      --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
      --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
-     --role="roles/storage.objectCreator"
+     --role="roles/storage.admin"
      ```
 
- 6. Add the `roles/storage.objectViewer` role.
-
-     ```shell
-     gcloud projects add-iam-policy-binding $PROJECT_ID \
-     --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
-     --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
-     --role="roles/storage.objectViewer"
-    ```
-
-
- 7. Add the `roles/artifactregistry.writer` role.
+ 6. Add the `roles/artifactregistry.writer` role.
 
      ```shell
      gcloud projects add-iam-policy-binding $PROJECT_ID \


### PR DESCRIPTION
This commit replaces the storage object specific permissions with storage admin in order to give the account `storage.buckets.get`, as well as create, because the logic to submit the job will actually attempt to create the GCS bucket if it doesn't exist. This is kinda pointless for us since we create it explicitly, however the error is distracting when running the notebook so I think it's worth getting rid of:

```
Error when trying to get or create a GCS bucket for the pipeline output artifacts
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/google/cloud/aiplatform/pipeline_jobs.py", line 424, in submit
    gcs_utils.create_gcs_bucket_for_pipeline_artifacts_if_it_does_not_exist(
  File "/opt/conda/lib/python3.10/site-packages/google/cloud/aiplatform/utils/gcs_utils.py", line 242, in create_gcs_bucket_for_pipeline_artifacts_if_it_does_not_exist
    if not pipelines_bucket.exists():
  File "/opt/conda/lib/python3.10/site-packages/google/cloud/storage/bucket.py", line 898, in exists
    client._get_resource(
  File "/opt/conda/lib/python3.10/site-packages/google/cloud/storage/client.py", line 387, in _get_resource
    return self._connection.api_request(
  File "/opt/conda/lib/python3.10/site-packages/google/cloud/storage/_http.py", line 72, in api_request
    return call()
  File "/opt/conda/lib/python3.10/site-packages/google/api_core/retry.py", line 349, in retry_wrapped_func
  File "/opt/conda/lib/python3.10/site-packages/google/api_core/retry.py", line 191, in retry_target
  File "/opt/conda/lib/python3.10/site-packages/google/cloud/_http/__init__.py", line 494, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.Forbidden: 403 GET https://storage.googleapis.com/storage/v1/b/catw-farm-rlhf-artifacts?fields=name&prettyPrint=false: 43727225970-compute@developer.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
```

Unfortunately there doesn't seem to be a more granular role we can use (https://cloud.google.com/storage/docs/access-control/iam-roles), the admin role is the only reasonable looking role that has bucket access.