### PR TITLE
Use more fine grained storage access permissions

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -82,22 +82,45 @@ Make sure the default Compute Engine [service account][sa] has sufficient permis
      --role="roles/aiplatform.user"
      ```
 
- 5. Add the `roles/storage.admin` role.
-
-     ```shell
-     gcloud projects add-iam-policy-binding $PROJECT_ID \
-     --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
-     --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
-     --role="roles/storage.admin"
-     ```
-
- 6. Add the `roles/artifactregistry.writer` role.
+ 5. Add the `roles/artifactregistry.writer` role.
 
      ```shell
      gcloud projects add-iam-policy-binding $PROJECT_ID \
      --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
      --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
      --role="roles/artifactregistry.writer"
+     ```
+
+ 6. Add the `roles/storage.objectCreator` role.
+
+    ```shell
+    gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
+    --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
+    --role="roles/storage.objectCreator"
+    ```
+
+ 7. Add the `roles/storage.objectViewer` role.
+
+    ```shell
+    gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
+    --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
+    --role="roles/storage.objectViewer"
+    ```
+
+ 6. Create a role for reading storage buckets and add it.
+
+     ```shell
+     gcloud iam roles create storageBucketGet \
+        --project=$PROJECT_ID \
+        --title="Storage Bucket Getter" \
+        --permissions="storage.buckets.get" 
+
+     gcloud projects add-iam-policy-binding $PROJECT_ID \
+     --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
+     --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
+     --role="projects/$PROJECT_ID/roles/storageBucketGet"
      ```
 
 ## Storage

--- a/text-bison-notebook.ipynb
+++ b/text-bison-notebook.ipynb
@@ -351,7 +351,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "! gsutil -m cp -r data {metadata.BUCKET_URI}"
+        "! gsutil -m cp -n -r data {metadata.BUCKET_URI}\n",
+        "\n",
+        "# If you want to overwrite the bucket contents, uncomment the following to run without -n\n",
+        "# The service account will need permission to delete objects in order to overwrite\n",
+        "# ! gsutil -m cp -r data {metadata.BUCKET_URI}"
       ]
     },
     {


### PR DESCRIPTION
## Use custom storage buckets get role

In order to run the notebook steps without errors, we need:
* `roles/storage.objectCreator`
* `roles/storage.objectViewer`
* `storage.buckets.get` <-- this isn't really necessary but the libs we
  are calling will try to see if the bucket we manually create exists
  and issue a noisy error if not

The only appropriate existing role that included `storage.buckets.get`
was the storage admin role which is overkill if we don't want the
account to actually be managing buckets. So instead we create a customer
role with exactly what we need.

## Don't try to overwrite data when uploading

When running the gsutil command portion of the notebook more than once,
it would previously try to overwrite existing files. This is useful if
you're making changes, but requires the running service account have
object deletion privileges. Instead of ballooning out these even more,
default to not overwriting.